### PR TITLE
FAQ / 关于 / 贡献指南措辞微调

### DIFF
--- a/content/en/about/_index.md
+++ b/content/en/about/_index.md
@@ -59,7 +59,7 @@ The zh in the name comes from ISO 639, the code for the Chinese language. It ide
 
 The public pages are also available in English, to make things easier for the gentoo-zh overlay's overseas users.
 
-Only the public pages (About, Download, Mirror list, Contributing) are fully in English; most of the technical articles are still Chinese-only, with only a few articles available in English. The English was drafted with translation software and then reviewed and polished by Claude Fable 5, so it may read a little stiff or have the odd slip — spot something? Open an issue or PR on [GitHub](https://github.com/Gentoo-zh/gentoo-zh.github.io).
+Only the public pages (About, Download, Mirror list, Contributing) are fully in English; only some of the technical articles have an English version. The English was drafted with translation software and then reviewed and polished by Claude Fable 5, so it may read a little stiff or have the odd slip — spot something? Open an issue or PR on [GitHub](https://github.com/Gentoo-zh/gentoo-zh.github.io).
 
 ## How can I help build the community?
 

--- a/content/en/contributing/_index.md
+++ b/content/en/contributing/_index.md
@@ -5,11 +5,11 @@ description: "How to contribute to the Gentoo-zh Overlay and the Gentoo-zh Commu
 
 Welcome to the Gentoo-zh Community! Contributions come in a few flavours:
 
-- **Contribute to the Gentoo-zh Overlay** (packages / ebuilds) — the main community track, and the source of the [contributor wall](/contributors/) (a script pulls everyone with 5+ commits to [gentoo-zh/overlay](https://github.com/gentoo-zh/overlay) every month). See "Contributing to the Gentoo-zh Overlay" below.
-- **Contribute to the community website** (articles / translations / fixes) — lives in the [gentoo-zh.github.io](https://github.com/Gentoo-zh/gentoo-zh.github.io) repo. See "Contributing to the community website" in the second half of this page.
+- **Contribute to the Gentoo-zh Overlay** (packages / ebuilds) — the main community track, and the source of the [contributor wall](/contributors/) (a script pulls everyone with 5+ commits to [gentoo-zh/overlay](https://github.com/gentoo-zh/overlay) every month). See "Gentoo-zh Overlay Contributing Guide" below.
+- **Contribute to the community website** (articles / translations / fixes) — lives in the [gentoo-zh.github.io](https://github.com/gentoo-zh/gentoo-zh.github.io) repo. See "Community Website Contributing Guide" in the second half of this page.
 - **Translate the official Gentoo Wiki** (Chinese translators) — see [How to help translate the Gentoo Wiki](https://gentoozh.org/posts/2026-06-30-gentoo-wiki-translation/).
 
-## Contributing to the Gentoo-zh Overlay
+## Gentoo-zh Overlay Contributing Guide
 
 gentoo-zh is a `masters = gentoo` Gentoo overlay (stacked on top of the official Portage tree) carrying 450+ packages, with its source at [gentoo-zh/overlay](https://github.com/gentoo-zh/overlay). Adding or updating ebuilds, fixing bugs, keeping up with new upstream releases — it all goes through GitHub Pull Requests. Found a problem? File an [issue](https://github.com/gentoo-zh/overlay/issues) too.
 
@@ -230,7 +230,7 @@ The how-to is **governed by the official docs**; this page is just a pointer:
 
 ---
 
-## Contributing to the community website (articles / translations / docs)
+## Community Website Contributing Guide (articles / translations / docs)
 
 ## Project overview
 

--- a/content/en/faq/_index.md
+++ b/content/en/faq/_index.md
@@ -27,12 +27,12 @@ When a direct connection to GitHub / the official distfiles is slow, point the o
 
 {{% details closed="true" title="Where do I go when I run into trouble?" %}}
 
-All the chat channels (Telegram, Matrix, IRC, etc.) are listed on the [About page](/about/); pick whichever you prefer. For overlay bugs, file an issue at [gentoo-zh/overlay](https://github.com/gentoo-zh/overlay/issues).
+We offer several chat channels (Telegram, Matrix, IRC, etc.), all listed on the [About page](/about/) — pick whichever you prefer. For overlay bugs, file an issue at [gentoo-zh/overlay](https://github.com/gentoo-zh/overlay/issues).
 
 {{% /details %}}
 
-{{% details closed="true" title="How do I start contributing?" %}}
+{{% details closed="true" title="How can I contribute to the community?" %}}
 
-Send packages / fix bugs for the overlay, or write articles / translations for the website. It's all in the [contributing guide](/contributing/).
+Send packages / fix bugs for the overlay, or write articles / translations for the website — see the [contributing guide](/contributing/).
 
 {{% /details %}}

--- a/content/zh-cn/about/_index.md
+++ b/content/zh-cn/about/_index.md
@@ -59,7 +59,7 @@ title: "关于"
 
 为了方便使用 gentoo-zh overlay 的海外用户，社区公共页面也提供英文版本。
 
-但目前只有公共页面（关于、下载、镜像列表、贡献指南）全部做了英文版本，具体的技术文章大多还是中文，只有少数文章提供英文版，英文内容是由翻译软件初译，再经 Claude Fable 5 校对优化，难免会有生硬或错漏，如果发现问题欢迎到 [GitHub](https://github.com/Gentoo-zh/gentoo-zh.github.io) 指正或提 PR。
+但目前只有公共页面（关于、下载、镜像列表、贡献指南）全部做了英文版本，具体的技术文章只有部分文章提供英文版，英文内容是由翻译软件初译，再经 Claude Fable 5 校对优化，难免会有生硬或错漏，如果发现问题欢迎到 [GitHub](https://github.com/Gentoo-zh/gentoo-zh.github.io) 指正或提 PR。
 
 ## 参与社区建设，我能做些什么？
 

--- a/content/zh-cn/contributing/_index.md
+++ b/content/zh-cn/contributing/_index.md
@@ -6,11 +6,11 @@ description: "如何为 Gentoo-zh Overlay 与 Gentoo 中文社区网站做出贡
 欢迎参与 Gentoo 中文社区！
 贡献分为：
 
-- **Gentoo-zh Overlay 贡献**（软件包 / ebuild）——社区主线，也是[贡献者墙](https://gentoozh.org/contributors/)的来源（脚本每月抓取 [gentoo-zh/overlay](https://github.com/gentoo-zh/overlay) 提交 5 次以上者）。详见下方「为 gentoo-zh Overlay 贡献」
-- **社区网站贡献**（文章 / 翻译 / 修正）——在 [gentoo-zh.github.io](https://github.com/Gentoo-zh/gentoo-zh.github.io) 仓库，详见本页后半「为社区网站贡献」
+- **Gentoo-zh Overlay 贡献**（软件包 / ebuild）——社区主线，也是[贡献者墙](https://gentoozh.org/contributors/)的来源（脚本每月抓取 [gentoo-zh/overlay](https://github.com/gentoo-zh/overlay) 提交 5 次以上者）。详见下方「Gentoo-zh Overlay 贡献指南」
+- **社区网站贡献**（文章 / 翻译 / 修正）——在 [gentoo-zh.github.io](https://github.com/gentoo-zh/gentoo-zh.github.io) 仓库，详见本页后半「社区网站贡献指南」
 - **官方 Gentoo Wiki 翻译**（中文译者）——见[如何参与 Gentoo Wiki 的翻译工作](https://gentoozh.org/posts/2026-06-30-gentoo-wiki-translation/)
 
-## 为 Gentoo-zh Overlay 贡献
+## Gentoo-zh Overlay 贡献指南
 
 gentoo-zh 是一个 `masters = gentoo` 的 Gentoo Overlay（叠加在官方 Portage 树之上），收录 450 多个包，源码在 [gentoo-zh/overlay](https://github.com/gentoo-zh/overlay)。新增或更新 ebuild、修 Bug、跟进新版本，都通过 GitHub Pull Request 提交；发现问题也欢迎提 [issue](https://github.com/gentoo-zh/overlay/issues)。
 

--- a/content/zh-cn/faq/_index.md
+++ b/content/zh-cn/faq/_index.md
@@ -3,7 +3,7 @@ title: "常见问题"
 description: "Gentoo 中文社区新手常见问题：从哪开始、Overlay 与官方源的关系、镜像加速、去哪提问、如何贡献。"
 ---
 
-新手最常问的几个。
+新手最常问的几个问题
 
 {{% details closed="true" title="我是新手，该从哪开始？用官方 Gentoo 还是社区 Live ISO？" %}}
 
@@ -27,12 +27,12 @@ Overlay 是叠加在官方 Portage 树之上的额外软件来源，官方源没
 
 {{% details closed="true" title="遇到问题去哪问？" %}}
 
-各种交流渠道（Telegram、Matrix、IRC 等）都列在 [关于页面](/about/)，按自己习惯挑一个。Overlay 的 bug 直接到 [gentoo-zh/overlay](https://github.com/gentoo-zh/overlay/issues) 提 issue。
+我们提供多种交流渠道（Telegram、Matrix、IRC 等），都列在 [关于页面](/about/) 里，可以按自己的喜好选择。Overlay 的 Bug 直接到 [gentoo-zh/overlay](https://github.com/gentoo-zh/overlay/issues) 提 issue。
 
 {{% /details %}}
 
-{{% details closed="true" title="如何开始贡献？" %}}
+{{% details closed="true" title="如何为社区贡献？" %}}
 
-给 Overlay 提包 / 修 bug、给网站写文章补翻译，流程都在 [贡献指南](/contributing/) 里。
+给 Overlay 提包 / 修 Bug、给网站写文章补翻译，请参考 [贡献指南](/contributing/) 。
 
 {{% /details %}}

--- a/content/zh-tw/about/_index.md
+++ b/content/zh-tw/about/_index.md
@@ -59,7 +59,7 @@ title: "關於"
 
 為了方便使用 gentoo-zh overlay 的海外使用者，社群公共頁面也提供英文版本。
 
-但目前只有公共頁面（關於、下載、鏡像列表、貢獻指南）全部做了英文版本，具體的技術文章大多還是中文，只有少數文章提供英文版，英文內容是由翻譯軟體初譯，再經 Claude Fable 5 校對最佳化，難免會有生硬或錯漏，如果發現問題歡迎到 [GitHub](https://github.com/Gentoo-zh/gentoo-zh.github.io) 指正或提 PR。
+但目前只有公共頁面（關於、下載、鏡像列表、貢獻指南）全部做了英文版本，具體的技術文章只有部分文章提供英文版，英文內容是由翻譯軟體初譯，再經 Claude Fable 5 校對最佳化，難免會有生硬或錯漏，如果發現問題歡迎到 [GitHub](https://github.com/Gentoo-zh/gentoo-zh.github.io) 指正或提 PR。
 
 ## 參與社群建設，我能做些什麼？
 

--- a/content/zh-tw/contributing/_index.md
+++ b/content/zh-tw/contributing/_index.md
@@ -6,11 +6,11 @@ description: "如何為 Gentoo-zh Overlay 與 Gentoo 中文社群網站做出貢
 歡迎參與 Gentoo 中文社群！
 貢獻分為：
 
-- **Gentoo-zh Overlay 貢獻**（軟體套件 / ebuild）——社群主線，也是[貢獻者牆](https://gentoozh.org/contributors/)的來源（指令碼每月抓取 [gentoo-zh/overlay](https://github.com/gentoo-zh/overlay) 提交 5 次以上者）。詳見下方「為 gentoo-zh Overlay 貢獻」
-- **社群網站貢獻**（文章 / 翻譯 / 修正）——在 [gentoo-zh.github.io](https://github.com/Gentoo-zh/gentoo-zh.github.io) 倉庫，詳見本頁後半「為社群網站貢獻」
+- **Gentoo-zh Overlay 貢獻**（軟體套件 / ebuild）——社群主線，也是[貢獻者牆](https://gentoozh.org/contributors/)的來源（指令碼每月抓取 [gentoo-zh/overlay](https://github.com/gentoo-zh/overlay) 提交 5 次以上者）。詳見下方「Gentoo-zh Overlay 貢獻指南」
+- **社群網站貢獻**（文章 / 翻譯 / 修正）——在 [gentoo-zh.github.io](https://github.com/gentoo-zh/gentoo-zh.github.io) 倉庫，詳見本頁後半「社群網站貢獻指南」
 - **官方 Gentoo Wiki 翻譯**（中文譯者）——見[如何參與 Gentoo Wiki 的翻譯工作](https://gentoozh.org/posts/2026-06-30-gentoo-wiki-translation/)
 
-## 為 Gentoo-zh Overlay 貢獻
+## Gentoo-zh Overlay 貢獻指南
 
 gentoo-zh 是一個 `masters = gentoo` 的 Gentoo Overlay（疊加在官方 Portage 樹之上），收錄 450 多個包，原始碼在 [gentoo-zh/overlay](https://github.com/gentoo-zh/overlay)。新增或更新 ebuild、修 Bug、跟進新版本，都透過 GitHub Pull Request 提交；發現問題也歡迎提 [issue](https://github.com/gentoo-zh/overlay/issues)。
 

--- a/content/zh-tw/faq/_index.md
+++ b/content/zh-tw/faq/_index.md
@@ -3,7 +3,7 @@ title: "常見問題"
 description: "Gentoo 中文社群新手常見問題：從哪開始、Overlay 與官方源的關係、鏡像加速、去哪提問、如何貢獻。"
 ---
 
-新手最常問的幾個。
+新手最常問的幾個問題
 
 {{% details closed="true" title="我是新手，該從哪開始？用官方 Gentoo 還是社群 Live ISO？" %}}
 
@@ -27,12 +27,12 @@ Overlay 是疊加在官方 Portage 樹之上的額外軟體來源，官方源沒
 
 {{% details closed="true" title="遇到問題去哪問？" %}}
 
-各種交流渠道（Telegram、Matrix、IRC 等）都列在 [關於頁面](/about/)，按自己習慣挑一個。Overlay 的 bug 直接到 [gentoo-zh/overlay](https://github.com/gentoo-zh/overlay/issues) 提 issue。
+我們提供多種交流渠道（Telegram、Matrix、IRC 等），都列在 [關於頁面](/about/) 裡，可以按自己的喜好選擇。Overlay 的 Bug 直接到 [gentoo-zh/overlay](https://github.com/gentoo-zh/overlay/issues) 提 issue。
 
 {{% /details %}}
 
-{{% details closed="true" title="如何開始貢獻？" %}}
+{{% details closed="true" title="如何為社群貢獻？" %}}
 
-給 Overlay 提包 / 修 bug、給網站寫文章補翻譯，流程都在 [貢獻指南](/contributing/) 裡。
+給 Overlay 提包 / 修 Bug、給網站寫文章補翻譯，請參考 [貢獻指南](/contributing/) 。
 
 {{% /details %}}


### PR DESCRIPTION
## Summary
- FAQ：完善提问语气、常见问题渠道说明
- 关于页：英文版覆盖率说明改为「部分文章有英文」
- 贡献指南：两处小节链接文案统一为「...贡献指南」、修正仓库链接大小写

简体源改动后用 sync_to_tw.sh 生成正体版，英文版手动跟进相应措辞。

## Test plan
- [x] hugo server -D 本地预览三语 FAQ / 关于 / 贡献指南
- [x] 确认 zh-tw 无 OpenCC 误转或残留占位符