### PR TITLE
导航加入「服务状态」外链

### DIFF
--- a/config/_default/menus.en.toml
+++ b/config/_default/menus.en.toml
@@ -36,6 +36,12 @@
   parent = "infra"
   weight = 1
 
+[[main]]
+  name = "Status"
+  url = "https://status.gentoozh.org/"
+  parent = "infra"
+  weight = 2
+
 # More ▾ (expand/collapse)
 [[main]]
   name = "More"

--- a/config/_default/menus.zh-cn.toml
+++ b/config/_default/menus.zh-cn.toml
@@ -36,6 +36,12 @@
   parent = "infra"
   weight = 1
 
+[[main]]
+  name = "服务状态"
+  url = "https://status.gentoozh.org/"
+  parent = "infra"
+  weight = 2
+
 # 更多 ▾（可展开收起）
 [[main]]
   name = "更多"

--- a/config/_default/menus.zh-tw.toml
+++ b/config/_default/menus.zh-tw.toml
@@ -36,6 +36,12 @@
   parent = "infra"
   weight = 1
 
+[[main]]
+  name = "服務狀態"
+  url = "https://status.gentoozh.org/"
+  parent = "infra"
+  weight = 2
+
 # 更多 ▾（可展開收起）
 [[main]]
   name = "更多"


### PR DESCRIPTION
在「基础设施 ▾」下拉菜单加入指向 https://status.gentoozh.org/ 的「服务状态」链接（简/繁/英三语,外链新标签打开）。

状态页托管于 Cloudflare 边缘,独立于社区服务器,实时显示主站/论坛/镜像/Matrix 的运行状态与 90 天可用率。

- config/_default/menus.zh-cn.toml — 服务状态
- config/_default/menus.zh-tw.toml — 服務狀態
- config/_default/menus.en.toml — Status

已本地 hugo 构建验证三语正常渲染。