### PR TITLE
新增「Overlay 软件包清理、改名与批量更新」三语公告

### DIFF
--- a/content/en/changelog/_index.md
+++ b/content/en/changelog/_index.md
@@ -11,6 +11,7 @@ This page tracks the major updates to the site's content, so readers can follow 
 
 ## July 2026
 
+- New announcement **[Package cleanup, renames and mass updates](/posts/2026-07-29-overlay-package-cleanup/)**: over the past month 162 packages were updated, 60 added, 38 removed and 5 renamed or moved, taking the overlay from 468 to 490 packages. The post lists the renames, the removals, and what each needs from you
 - **The Live ISO download site is now [iso.gentoozh.org](https://iso.gentoozh.org/)**: it serves Live ISO downloads, not Gentoo's portage / distfiles mirrors (those are on the [mirror list](/en/mirrorlist/) page), so the old `mirror` name was misleading. The old address mirror.gentoozh.org still works, so bookmarks and existing links keep working
 - **The community Pastebin [paste.gentoozh.org](https://paste.gentoozh.org) is live** (built on [wastebin](https://github.com/matze/wastebin)): for sharing code and logs, with a web UI, command line (curl), and raw links. Entry points have been added in the top-bar "Infrastructure" menu and the [Pastebin guide](/paste/)
 - The [About page](/about/) now links to the community's page on the **Gentoo Wiki** ([Gentoo-zh](https://wiki.gentoo.org/wiki/Gentoo-zh)), with structured-data `sameAs`

--- a/content/en/posts/2026-07-29-overlay-package-cleanup/index.md
+++ b/content/en/posts/2026-07-29-overlay-package-cleanup/index.md
@@ -1,0 +1,104 @@
+---
+title: "Package Cleanup, Renames and Mass Updates"
+description: "Over the past month the gentoo-zh overlay updated 162 packages, added 60, removed 38 and renamed or moved 5, going from 468 to 490 packages. Here are the rename and removal lists, and what each one needs from you."
+date: 2026-07-29
+tags: ["announcement", "overlay"]
+authors:
+  - name: Zakk
+    image: /contributors/zakkaus/feature.webp
+    link: https://github.com/zakkaus
+---
+
+Over the past month 162 packages were updated to a newer upstream release, 60 packages were added, 38 were removed and 5 were renamed or moved to another category. The overlay went from 468 to 490 packages.
+
+{{< callout type="info" >}}
+The same text also ships as an overlay news item — after `emerge --sync` you can read it with `eselect news read`.
+{{< /callout >}}
+
+## Renamed or Moved
+
+The five packages below were renamed or moved. Portage applies this on `emerge --sync`, nothing has to be done by hand:
+
+| Old name | New name |
+| --- | --- |
+| `app-i18n/fcitx5-vinput` | `app-i18n/fcitx-vinput` |
+| `www-apps/cherry-studio-bin` | `app-misc/cherry-studio-bin` |
+| `www-apps/dufs` | `www-servers/dufs` |
+| `www-apps/follow-bin` | `www-apps/folo-bin` |
+| `net-proxy/clash-verge-bin` | `net-proxy/clash-verge-rev-bin` |
+
+## Now Provided by ::gentoo
+
+::gentoo carries the same or a newer version of the seven packages below, so this overlay no longer keeps a second copy. After syncing they come from ::gentoo, installed copies need no action and upgrades follow ::gentoo from now on:
+
+- `dev-libs/libdatrie`
+- `dev-libs/libthai`
+- `dev-libs/libratbag`
+- `gui-libs/libdecor`
+- `media-fonts/smiley-sans`
+- `sys-fs/jmtpfs`
+- `media-video/amdgpu-pro-amf`
+
+## Removed: Upstream Gone or Unmaintained
+
+These ten were removed because upstream disappeared, archived the project or nobody maintains them any more:
+
+- `app-containers/distrobox-boost`
+- `dev-db/dbeaver-bin`
+- `dev-python/pytube`
+- `net-misc/bbdown-bin`
+- `net-misc/biliup-rs`
+- `net-print/kyodialog`
+- `net-proxy/mihomo-party-bin`
+- `net-proxy/tun2socks`
+- `x11-misc/snapd-xdg-open`
+- `x11-themes/fcitx-breeze`
+
+## Removed: Long Unmaintained
+
+The twenty-one below were all added by the same packager, went unmaintained for a long time and had no second maintainer, so they were removed together:
+
+- `app-doc/reeknote`
+- `app-editors/flowblade`
+- `app-office/evernote-repack`
+- `app-text/tre`
+- `app-text/wik`
+- `app-text/wiki2man_on_rust`
+- `dev-python/exifread`
+- `dev-python/iptcinfo3`
+- `dev-python/mwparserfromhell`
+- `dev-python/pywikibot`
+- `dev-vcs/git-remote-mediawiki`
+- `games-emulation/conty`
+- `games-fps/openarena`
+- `games-fps/openarena-bin`
+- `games-roguelike/tsl`
+- `games-strategy/zedonline-bin`
+- `mate-base/caja-bin`
+- `media-sound/rew`
+- `media-sound/yamusic-tui-bin`
+- `net-im/kotatogram-bin`
+- `x11-themes/kvantum-black`
+
+{{< callout type="warning" >}}
+An installed copy of a removed package stays behind as an orphan and can be removed with `emerge --unmerge`.
+{{< /callout >}}
+
+## Replacement
+
+Upstream moved the `net-misc/biliup-rs` code to [biliup/biliup](https://github.com/biliup/biliup), so the replacement is `net-misc/biliup-bin`, the prebuilt binary from that repository.
+
+## More Packages Masked for Removal
+
+More packages are masked for removal. The reason and the removal date for each are in [`profiles/package.mask`](https://github.com/gentoo-zh/overlay/blob/master/profiles/package.mask). If you still use one of them, tell us before its removal date.
+
+## Feedback
+
+If an update breaks a build or breaks something at runtime, please report it:
+
+- [GitHub issues](https://github.com/gentoo-zh/overlay/issues)
+- overlay@gentoozh.org
+- [Telegram group](https://t.me/gentoo_zh)
+- [Community forum](https://forum.gentoozh.org/) (new forum)
+
+For longer logs please use [paste.gentoozh.org](https://paste.gentoozh.org/).

--- a/content/zh-cn/changelog/_index.md
+++ b/content/zh-cn/changelog/_index.md
@@ -11,6 +11,7 @@ slug: "changelog"
 
 ## 2026 年 7 月
 
+- 新增公告 **[Overlay 软件包清理、改名与批量更新](/posts/2026-07-29-overlay-package-cleanup/)**：过去一个月升级 162 个包、新增 60 个、移除 38 个、改名或换分类 5 个，overlay 从 468 个包变成 490 个；文中列出改名清单、移除清单与各自的处理办法
 - **Live ISO 下载站改用 [iso.gentoozh.org](https://iso.gentoozh.org/)**：站点服务的是 Live ISO 下载，不是 Gentoo 的 portage / distfiles 镜像（那些在[镜像列表](/mirrorlist/)页），原来的 mirror 名字容易误解；旧地址 mirror.gentoozh.org 继续可用，书签和已有链接不失效
 - **社区 Pastebin [paste.gentoozh.org](https://paste.gentoozh.org) 上线**（基于 [wastebin](https://github.com/matze/wastebin)）：贴代码 / 日志用，支持网页、命令行（curl）与 raw 链接；顶栏「基础设施」菜单和 [Pastebin 使用说明](/paste/) 已加入口
 - [关于页](/about/)补上社区在 **Gentoo Wiki** 的页面链接（[User:Gentoo-zh](https://wiki.gentoo.org/wiki/User:Gentoo-zh)），并加入结构化数据 `sameAs`

--- a/content/zh-cn/posts/2026-07-29-overlay-package-cleanup/index.md
+++ b/content/zh-cn/posts/2026-07-29-overlay-package-cleanup/index.md
@@ -1,0 +1,104 @@
+---
+title: "Overlay 软件包清理、改名与批量更新"
+description: "过去一个月 gentoo-zh overlay 升级 162 个包、新增 60 个、移除 38 个、改名或换分类 5 个，包数从 468 变成 490。本文列出改名与移除清单，以及各自需要怎么处理。"
+date: 2026-07-29
+tags: ["announcement", "overlay"]
+authors:
+  - name: Zakk
+    image: /contributors/zakkaus/feature.webp
+    link: https://github.com/zakkaus
+---
+
+过去一个月：162 个包升级到上游新版本，新增 60 个包，移除 38 个，5 个改名或换了分类。overlay 从 468 个包变成 490 个。
+
+{{< callout type="info" >}}
+同样的内容也作为 overlay 的新闻条目发布，`emerge --sync` 之后可以用 `eselect news read` 阅读。
+{{< /callout >}}
+
+## 改名与换分类
+
+下面五个包已改名或换分类。`emerge --sync` 之后 portage 会自动迁移，无需手动处理：
+
+| 原包名 | 现包名 |
+| --- | --- |
+| `app-i18n/fcitx5-vinput` | `app-i18n/fcitx-vinput` |
+| `www-apps/cherry-studio-bin` | `app-misc/cherry-studio-bin` |
+| `www-apps/dufs` | `www-servers/dufs` |
+| `www-apps/follow-bin` | `www-apps/folo-bin` |
+| `net-proxy/clash-verge-bin` | `net-proxy/clash-verge-rev-bin` |
+
+## 改由 ::gentoo 提供
+
+下面七个包 ::gentoo 已经有同版本或更新的一份，本 overlay 不再维护第二份。同步后改由 ::gentoo 提供，已安装的无需处理，后续升级来自 ::gentoo：
+
+- `dev-libs/libdatrie`
+- `dev-libs/libthai`
+- `dev-libs/libratbag`
+- `gui-libs/libdecor`
+- `media-fonts/smiley-sans`
+- `sys-fs/jmtpfs`
+- `media-video/amdgpu-pro-amf`
+
+## 移除：上游消失、封存或无人维护
+
+因为上游消失、封存或无人维护，所以删除下面十个包：
+
+- `app-containers/distrobox-boost`
+- `dev-db/dbeaver-bin`
+- `dev-python/pytube`
+- `net-misc/bbdown-bin`
+- `net-misc/biliup-rs`
+- `net-print/kyodialog`
+- `net-proxy/mihomo-party-bin`
+- `net-proxy/tun2socks`
+- `x11-misc/snapd-xdg-open`
+- `x11-themes/fcitx-breeze`
+
+## 移除：长期无人维护
+
+因为下面二十一个包由同一位打包者加入后长期无人维护、也没有第二维护人，所以一并移除：
+
+- `app-doc/reeknote`
+- `app-editors/flowblade`
+- `app-office/evernote-repack`
+- `app-text/tre`
+- `app-text/wik`
+- `app-text/wiki2man_on_rust`
+- `dev-python/exifread`
+- `dev-python/iptcinfo3`
+- `dev-python/mwparserfromhell`
+- `dev-python/pywikibot`
+- `dev-vcs/git-remote-mediawiki`
+- `games-emulation/conty`
+- `games-fps/openarena`
+- `games-fps/openarena-bin`
+- `games-roguelike/tsl`
+- `games-strategy/zedonline-bin`
+- `mate-base/caja-bin`
+- `media-sound/rew`
+- `media-sound/yamusic-tui-bin`
+- `net-im/kotatogram-bin`
+- `x11-themes/kvantum-black`
+
+{{< callout type="warning" >}}
+已安装的被删除包会成为孤儿包，可用 `emerge --unmerge` 移除。
+{{< /callout >}}
+
+## 替代包
+
+因为上游把 `net-misc/biliup-rs` 的代码迁到 [biliup/biliup](https://github.com/biliup/biliup)，所以改用该仓库的预编译版本，包名为 `net-misc/biliup-bin`。
+
+## 还有一批已 mask 待移除
+
+另有一批包已经 mask 待移除，原因和移除日期写在 [`profiles/package.mask`](https://github.com/gentoo-zh/overlay/blob/master/profiles/package.mask) 里。如果仍在使用其中的包，请在移除日期之前告知。
+
+## 反馈
+
+更新后如果遇到构建失败或运行异常，请向我们反馈：
+
+- [GitHub issues](https://github.com/gentoo-zh/overlay/issues)
+- overlay@gentoozh.org
+- [Telegram 群](https://t.me/gentoo_zh)
+- [社区论坛](https://forum.gentoozh.org/)（新开的论坛）
+
+若需附带较长的日志，请使用 [paste.gentoozh.org](https://paste.gentoozh.org/)。

--- a/content/zh-tw/changelog/_index.md
+++ b/content/zh-tw/changelog/_index.md
@@ -11,6 +11,7 @@ slug: "changelog"
 
 ## 2026 年 7 月
 
+- 新增公告 **[Overlay 軟體套件清理、改名與批次更新](/posts/2026-07-29-overlay-package-cleanup/)**：過去一個月升級 162 個包、新增 60 個、移除 38 個、改名或換分類 5 個，overlay 從 468 個包變成 490 個；文中列出改名清單、移除清單與各自的處理辦法
 - **Live ISO 下載站改用 [iso.gentoozh.org](https://iso.gentoozh.org/)**：站點服務的是 Live ISO 下載，不是 Gentoo 的 portage / distfiles 鏡像（那些在[鏡像列表](/zh-tw/mirrorlist/)頁），原來的 mirror 名字容易誤解；舊地址 mirror.gentoozh.org 繼續可用，書籤和已有連結不失效
 - **社群 Pastebin [paste.gentoozh.org](https://paste.gentoozh.org) 上線**（基於 [wastebin](https://github.com/matze/wastebin)）：貼程式碼 / 日誌用，支援網頁、指令列（curl）與 raw 連結；頂欄「基礎設施」選單和 [Pastebin 使用說明](/paste/) 已加入口
 - [關於頁](/about/)補上社群在 **Gentoo Wiki** 的頁面連結（[User:Gentoo-zh](https://wiki.gentoo.org/wiki/User:Gentoo-zh)），並加入結構化資料 `sameAs`

--- a/content/zh-tw/posts/2026-07-29-overlay-package-cleanup/index.md
+++ b/content/zh-tw/posts/2026-07-29-overlay-package-cleanup/index.md
@@ -1,0 +1,104 @@
+---
+title: "Overlay 軟體套件清理、改名與批次更新"
+description: "過去一個月 gentoo-zh overlay 升級 162 個包、新增 60 個、移除 38 個、改名或換分類 5 個，包數從 468 變成 490。本文列出改名與移除清單，以及各自需要怎麼處理。"
+date: 2026-07-29
+tags: ["announcement", "overlay"]
+authors:
+  - name: Zakk
+    image: /contributors/zakkaus/feature.webp
+    link: https://github.com/zakkaus
+---
+
+過去一個月：162 個包升級到上游新版本，新增 60 個包，移除 38 個，5 個改名或換了分類。overlay 從 468 個包變成 490 個。
+
+{{< callout type="info" >}}
+同樣的內容也作為 overlay 的新聞條目釋出，`emerge --sync` 之後可以用 `eselect news read` 閱讀。
+{{< /callout >}}
+
+## 改名與換分類
+
+下面五個包已改名或換分類。`emerge --sync` 之後 portage 會自動遷移，無需手動處理：
+
+| 原套件名 | 現套件名 |
+| --- | --- |
+| `app-i18n/fcitx5-vinput` | `app-i18n/fcitx-vinput` |
+| `www-apps/cherry-studio-bin` | `app-misc/cherry-studio-bin` |
+| `www-apps/dufs` | `www-servers/dufs` |
+| `www-apps/follow-bin` | `www-apps/folo-bin` |
+| `net-proxy/clash-verge-bin` | `net-proxy/clash-verge-rev-bin` |
+
+## 改由 ::gentoo 提供
+
+下面七個包 ::gentoo 已經有同版本或更新的一份，本 overlay 不再維護第二份。同步後改由 ::gentoo 提供，已安裝的無需處理，後續升級來自 ::gentoo：
+
+- `dev-libs/libdatrie`
+- `dev-libs/libthai`
+- `dev-libs/libratbag`
+- `gui-libs/libdecor`
+- `media-fonts/smiley-sans`
+- `sys-fs/jmtpfs`
+- `media-video/amdgpu-pro-amf`
+
+## 移除：上游消失、封存或無人維護
+
+因為上游消失、封存或無人維護，所以刪除下面十個包：
+
+- `app-containers/distrobox-boost`
+- `dev-db/dbeaver-bin`
+- `dev-python/pytube`
+- `net-misc/bbdown-bin`
+- `net-misc/biliup-rs`
+- `net-print/kyodialog`
+- `net-proxy/mihomo-party-bin`
+- `net-proxy/tun2socks`
+- `x11-misc/snapd-xdg-open`
+- `x11-themes/fcitx-breeze`
+
+## 移除：長期無人維護
+
+因為下面二十一個包由同一位打包者加入後長期無人維護、也沒有第二維護人，所以一併移除：
+
+- `app-doc/reeknote`
+- `app-editors/flowblade`
+- `app-office/evernote-repack`
+- `app-text/tre`
+- `app-text/wik`
+- `app-text/wiki2man_on_rust`
+- `dev-python/exifread`
+- `dev-python/iptcinfo3`
+- `dev-python/mwparserfromhell`
+- `dev-python/pywikibot`
+- `dev-vcs/git-remote-mediawiki`
+- `games-emulation/conty`
+- `games-fps/openarena`
+- `games-fps/openarena-bin`
+- `games-roguelike/tsl`
+- `games-strategy/zedonline-bin`
+- `mate-base/caja-bin`
+- `media-sound/rew`
+- `media-sound/yamusic-tui-bin`
+- `net-im/kotatogram-bin`
+- `x11-themes/kvantum-black`
+
+{{< callout type="warning" >}}
+已安裝的被刪除包會成為孤兒包，可用 `emerge --unmerge` 移除。
+{{< /callout >}}
+
+## 替代包
+
+因為上游把 `net-misc/biliup-rs` 的程式碼遷到 [biliup/biliup](https://github.com/biliup/biliup)，所以改用該倉庫的預編譯版本，套件名為 `net-misc/biliup-bin`。
+
+## 還有一批已 mask 待移除
+
+另有一批包已經 mask 待移除，原因和移除日期寫在 [`profiles/package.mask`](https://github.com/gentoo-zh/overlay/blob/master/profiles/package.mask) 裡。如果仍在使用其中的包，請在移除日期之前告知。
+
+## 反饋
+
+更新後如果遇到建置失敗或執行異常，請向我們反饋：
+
+- [GitHub issues](https://github.com/gentoo-zh/overlay/issues)
+- overlay@gentoozh.org
+- [Telegram 群](https://t.me/gentoo_zh)
+- [社群論壇](https://forum.gentoozh.org/)（新開的論壇）
+
+若需附帶較長的日誌，請使用 [paste.gentoozh.org](https://paste.gentoozh.org/)。


### PR DESCRIPTION
把 overlay 的清理草稿上架成站内文章,正文照搬原文,只做排版。

## 新增

- `content/{zh-cn,zh-tw,en}/posts/2026-07-29-overlay-package-cleanup/`

排版处理:

- 改名的五个包用表格列出原名与现名
- 三组包名(交回 ::gentoo 的 7 个、上游消失的 10 个、长期无人维护的 21 个)改成列表,包名用行内代码,方便搜
- 孤儿包用 `emerge --unmerge` 处理放一个 callout
- `profiles/package.mask`、biliup/biliup 仓库,以及 issues / 邮箱 / Telegram / 论坛 / paste 都补上链接

繁体由 `sync_to_tw.sh` 从简体生成,英文按草稿的 en 版排版。

## 顺带

- 三语 `changelog/_index.md` 的「2026 年 7 月」下各加一条指向本文

## 说明

- 文章日期用的是 2026-07-29,需要改可以调 front matter 的 `date` 和目录名
- 正文没有提 GLEP 42 新闻条目:那条还没定要不要发
- 没有加 `draft: true`,合并后会直接上线

`hugo --gc --minify` 构建通过,三语页面都已生成。