### PR TITLE
posts：清理软件包公告去掉新闻条目那句，并改准升级的说法

### DIFF
--- a/content/en/posts/2026-07-29-overlay-package-cleanup/index.md
+++ b/content/en/posts/2026-07-29-overlay-package-cleanup/index.md
@@ -9,11 +9,7 @@ authors:
     link: https://github.com/zakkaus
 ---
 
-Over the past month 162 packages were updated to a newer upstream release, 60 packages were added, 38 were removed and 5 were renamed or moved to another category. The overlay went from 468 to 490 packages.
-
-{{< callout type="info" >}}
-The same text also ships as an overlay news item — after `emerge --sync` you can read it with `eselect news read`.
-{{< /callout >}}
+Over the past month 162 packages got a new version, 60 packages were added, 38 were removed and 5 were renamed or moved to another category. The overlay went from 468 to 490 packages.
 
 ## Renamed or Moved
 

--- a/content/zh-cn/posts/2026-07-29-overlay-package-cleanup/index.md
+++ b/content/zh-cn/posts/2026-07-29-overlay-package-cleanup/index.md
@@ -9,11 +9,7 @@ authors:
     link: https://github.com/zakkaus
 ---
 
-过去一个月：162 个包升级到上游新版本，新增 60 个包，移除 38 个，5 个改名或换了分类。overlay 从 468 个包变成 490 个。
-
-{{< callout type="info" >}}
-同样的内容也作为 overlay 的新闻条目发布，`emerge --sync` 之后可以用 `eselect news read` 阅读。
-{{< /callout >}}
+过去一个月：162 个包出了新版本，新增 60 个包，移除 38 个，5 个改名或换了分类。overlay 从 468 个包变成 490 个。
 
 ## 改名与换分类
 

--- a/content/zh-tw/posts/2026-07-29-overlay-package-cleanup/index.md
+++ b/content/zh-tw/posts/2026-07-29-overlay-package-cleanup/index.md
@@ -9,11 +9,7 @@ authors:
     link: https://github.com/zakkaus
 ---
 
-過去一個月：162 個包升級到上游新版本，新增 60 個包，移除 38 個，5 個改名或換了分類。overlay 從 468 個包變成 490 個。
-
-{{< callout type="info" >}}
-同樣的內容也作為 overlay 的新聞條目釋出，`emerge --sync` 之後可以用 `eselect news read` 閱讀。
-{{< /callout >}}
+過去一個月：162 個包出了新版本，新增 60 個包，移除 38 個，5 個改名或換了分類。overlay 從 468 個包變成 490 個。
 
 ## 改名與換分類
 


### PR DESCRIPTION
一个提交,三个文件(简/繁/英)。前两个提交已随 #27 合并,rebase 后从本 PR 去掉。

## 去掉新闻条目那句

因为 GLEP 42 新闻条目还没决定要不要发,所以删掉说它已经发布、可以用 `eselect news read` 阅读的那段。

这段在 #24 里已经删过一次,但 GitHub 当时没把 PR 的 head 同步到修改后的提交,合并进来的是旧版,所以现在还在线上。

## 改准升级的说法

"过去一个月：162 个包升级到上游新版本" 改成 "162 个包出了新版本"。因为这 162 个里有 5 个只是 Gentoo 侧的 `-rN` 修订、上游并没有出新版:

- `app-text/groff-utf8`
- `dev-python/numba`
- `media-gfx/scangearmp`
- `media-video/wiliwili`
- `net-print/epson-inkjet-printer_201207w`

## 数字核对

对着 `gentoo-zh/overlay` 逐个核对过(2026-06-26 至 07-28,仓库 HEAD `a165895`):

| 文中 | 实际 |
| --- | --- |
| 162 个包出新版本 | 162(排除只动了 9999 live ebuild 的那个) |
| 新增 60 | 60(扣掉 5 个改名后的新包名) |
| 移除 38 | 38(扣掉 5 个改名前的旧包名) |
| 改名或换分类 5 | 5,五组新旧包名逐一验证 |
| 468 到 490 | 468 到 490 |

移除的 38 个包名与文中三段清单(交回 `::gentoo` 的 7 个、上游消失的 10 个、长期无人维护的 21 个)完全吻合。

繁体由 `sync_to_tw.sh` 生成。全站构建通过。